### PR TITLE
[Feat] Message 조회 수신자, 방문자 분리

### DIFF
--- a/src/main/java/edu/skku/cc/domain/Message.java
+++ b/src/main/java/edu/skku/cc/domain/Message.java
@@ -81,4 +81,8 @@ public class Message extends BaseTimeEntity {
     public void solveQuiz() {
         this.quiz.solve();
     }
+
+    public void openMessage() {
+        this.isOpened = true;
+    }
 }

--- a/src/main/java/edu/skku/cc/exception/ErrorType.java
+++ b/src/main/java/edu/skku/cc/exception/ErrorType.java
@@ -12,30 +12,30 @@ public enum ErrorType {
     /**
      * 400 BAD REQUEST
      */
-    REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
-    INVALID_PULL_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "뽑지 않은 쪽지가 5개 미만입니다"),
-    INVALID_SOLVE_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 풀린 퀴즈입니다"),
-    WRONG_ANSWER_EXCEPTION(HttpStatus.BAD_REQUEST, "퀴즈 정답이 아닙니다"),
-    INVALID_FILE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
+    REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_PULL_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "뽑지 않은 쪽지가 5개 미만입니다."),
+    INVALID_SOLVE_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 풀린 퀴즈입니다."),
+    WRONG_ANSWER_EXCEPTION(HttpStatus.BAD_REQUEST, "퀴즈 정답이 아닙니다."),
+    INVALID_FILE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 
     /**
      * 401 UNAUTHORIZED
      */
-    // INVALID_USER(HttpStatus.UNAUTHORIZED, "접근 권한이 없는 유저입니다."),
+    UNAUTHORIZED_USER_EXCEPTION(HttpStatus.UNAUTHORIZED, "접근 권한이 없는 유저입니다."),
 
 
     /**
      * 404 NOT FOUND
      */
-    INVALID_USER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
-    INVALID_MESSAGE(HttpStatus.NOT_FOUND, "존재하지 않는 메시지입니다."),
+    INVALID_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    INVALID_MESSAGE_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 메시지입니다."),
 
 
     /*
      * 500 INTERNAL SERVER ERROR
      */
 
-    FILE_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다");
+    FILE_UPLOAD_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/edu/skku/cc/service/MessageService.java
+++ b/src/main/java/edu/skku/cc/service/MessageService.java
@@ -16,6 +16,7 @@ import edu.skku.cc.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,7 +51,7 @@ public class MessageService {
      */
     public List<MessageResponseDto> getUserPulledMessageList(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER_EXCEPTION));
         List<Message> messageList = user.getMessages();
 
         return messageList.stream()
@@ -60,19 +61,42 @@ public class MessageService {
                 .collect(Collectors.toList());
     }
 
+    public List<MessageResponseDto> getUserPublicPulledMessageList(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER_EXCEPTION));
+        List<Message> messageList = user.getMessages();
+
+        return messageList.stream()
+                .filter(message -> message.getIsPulled() && message.getIsPublic())
+                .sorted((m1, m2) -> m2.getPulledAt().compareTo(m1.getPulledAt()))
+                .map(MessageResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
     public MessageResponseDto getSingleUserMessage(Long userId, Long messageId) {
-//        User user = userRepository.getUserById(userId);
-        // 수신인이면 open 여부 체크하기
         Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE_EXCEPTION));
+        // open 여부 체크
+        if(!message.getIsOpened()) {
+            message.openMessage();
+        }
+        return MessageResponseDto.of(message);
+    }
+
+    public MessageResponseDto getSingleUserPublicMessage(Long userId, Long messageId) {
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE_EXCEPTION));
+
+        if (!message.getIsPublic()) {
+            throw new CustomException(ErrorType.UNAUTHORIZED_USER_EXCEPTION);
+        }
         return MessageResponseDto.of(message);
     }
 
     @Transactional
     public MessagePublicUpdateResponseDto updateMessagePublic(Long userId, Long messageId) {
-        // 메시지 수신인인지 체크
         Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE_EXCEPTION));
         message.updateIsPublic();
         return MessagePublicUpdateResponseDto.builder()
                 .messageId(message.getId())
@@ -85,7 +109,7 @@ public class MessageService {
      */
     public Long getRemainMessageCount(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER_EXCEPTION));
         List<Message> messageList = user.getMessages();
         return messageList.stream()
                 .filter(message -> !message.getIsPulled())
@@ -98,7 +122,7 @@ public class MessageService {
     @Transactional
     public Integer pullMessage(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER_EXCEPTION));
         List<Message> messageList = user.getMessages();
 
         // 5개 미만인 경우
@@ -123,10 +147,8 @@ public class MessageService {
     }
 
     public void solveMessageQuiz(Long userId, Long messageId, String answer) {
-
-        // 메시지 수신인인지 체크
         Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE_EXCEPTION));
         Quiz messageQuiz = message.getQuiz();
         if (messageQuiz.getIsSolved()) {
             throw new CustomException(ErrorType.INVALID_SOLVE_REQUEST_EXCEPTION);
@@ -141,7 +163,6 @@ public class MessageService {
 
     @Transactional
     public Long deleteMessage(Long userId, Long messageId) {
-        // 권한 체크
         Message message = messageRepository.findById(messageId)
                 .orElseThrow(() -> new CustomException(ErrorType.INVALID_MESSAGE));
         messageRepository.delete(message);
@@ -161,7 +182,7 @@ public class MessageService {
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER));
+                .orElseThrow(() -> new CustomException(ErrorType.INVALID_USER_EXCEPTION));
 
         Message message = Message.builder()
                 .user(user)


### PR DESCRIPTION
- 수신자 본인 아니면 안 되는 API들은 컨트롤러 단에서 @PreAuthorize
- 메시지 조회의 경우 컨트롤러에서 수신자 본인이면 모두 조회, 방문자면 public만 조회하도록